### PR TITLE
Add Dockerfile for builder and runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine AS build
+RUN apk add --update --no-cache ca-certificates git
+ADD . /src
+RUN cd /src && CGO_ENABLED=0 go build -o fping-exporter
+
+FROM alpine:latest
+RUN apk add --update --no-cache ca-certificates fping
+COPY --from=build /src/fping-exporter /
+EXPOSE 9605
+ENTRYPOINT ["/fping-exporter", "--fping=/usr/sbin/fping"]
+


### PR DESCRIPTION
Depends on #2 

- Adds 2-stage `Dockerfile` to build fping-exporter, and produce a small runnable image.

## Usage:

### Build image:
`$ docker build -t fping-exporter .`

```
Starting build of fping-exporter:latest...
Step 1/9 : FROM golang:alpine AS build
---> 3024b4e742b0
Step 2/9 : RUN apk add --update --no-cache ca-certificates git
---> Running in 5f22a5ebaf68
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/5) Installing nghttp2-libs (1.39.2-r0)
(2/5) Installing libcurl (7.66.0-r0)
(3/5) Installing expat (2.2.8-r0)
(4/5) Installing pcre2 (10.33-r0)
(5/5) Installing git (2.22.0-r0)
Executing busybox-1.30.1-r2.trigger
OK: 21 MiB in 20 packages
Removing intermediate container 5f22a5ebaf68
---> 2d6b2764a0cc
Step 3/9 : ADD . /src
---> b17f94c0397f
Step 4/9 : RUN cd /src && CGO_ENABLED=0 go build -o fping-exporter
---> Running in ddc3929ff18e
go: downloading github.com/prometheus/client_golang v1.2.1
go: downloading github.com/jessevdk/go-flags v1.4.0
go: extracting github.com/jessevdk/go-flags v1.4.0
go: extracting github.com/prometheus/client_golang v1.2.1
go: downloading github.com/prometheus/common v0.7.0
go: downloading github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
go: downloading github.com/golang/protobuf v1.3.2
go: downloading github.com/cespare/xxhash/v2 v2.1.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/prometheus/procfs v0.0.5
go: extracting github.com/cespare/xxhash/v2 v2.1.0
go: extracting github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
go: extracting github.com/beorn7/perks v1.0.1
go: extracting github.com/prometheus/common v0.7.0
go: extracting github.com/golang/protobuf v1.3.2
go: extracting github.com/prometheus/procfs v0.0.5
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: extracting github.com/matttproud/golang_protobuf_extensions v1.0.1
go: finding github.com/jessevdk/go-flags v1.4.0
go: finding github.com/prometheus/client_golang v1.2.1
go: finding github.com/beorn7/perks v1.0.1
go: finding github.com/cespare/xxhash/v2 v2.1.0
go: finding github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
go: finding github.com/golang/protobuf v1.3.2
go: finding github.com/prometheus/common v0.7.0
go: finding github.com/prometheus/procfs v0.0.5
go: finding github.com/matttproud/golang_protobuf_extensions v1.0.1
Removing intermediate container ddc3929ff18e
---> 00db1f943cdd
Step 5/9 : FROM alpine:latest
---> 965ea09ff2eb
Step 6/9 : RUN apk add --update --no-cache ca-certificates fping
---> Running in da4b1561d09d
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/2) Installing ca-certificates (20190108-r0)
(2/2) Installing fping (4.2-r0)
Executing busybox-1.30.1-r2.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 6 MiB in 16 packages
Removing intermediate container da4b1561d09d
---> d9c8e0986056
Step 7/9 : COPY --from=build /src/fping-exporter /
---> a9bde318690e
Step 8/9 : EXPOSE 9605
---> Running in b16120877f9b
Removing intermediate container b16120877f9b
---> de2b09dfd165
Step 9/9 : ENTRYPOINT ["/fping-exporter", "--fping=/usr/sbin/fping"]
---> Running in e1029766d0a6
Removing intermediate container e1029766d0a6
---> a2d4c34dc2b4
Successfully built a2d4c34dc2b4
Successfully tagged bbrks/fping-exporter:latest
Pushing index.docker.io/bbrks/fping-exporter:latest...
Done!
Build finished
```


### Run image:
`$ docker run -d -p 9605:9605 fping-exporter`

### Image stats:
`$ docker images | grep fping-exporter`

```
fping-exporter                                latest              a2d4c34dc2b4        4 days ago          18.2MB
```